### PR TITLE
add startVideoAt feature

### DIFF
--- a/language/ar.json
+++ b/language/ar.json
@@ -23,6 +23,10 @@
                   "description": "معلومات بشأن حقوق الطبع والنشر من شريط الفيديو والعناصر المستخدمة في الفيديو"
                 },
                 {
+                  "label": "Start video at",
+                  "description": "Enter timecode in the format M:SS"
+                },
+                {
                   "label": "Video start screen options",
                   "fields": [
                     {

--- a/language/de.json
+++ b/language/de.json
@@ -23,6 +23,10 @@
                   "description": "Urheberrechtliche Informationen zum Video und zu den Elemente, die im Video verwendet werden."
                 },
                 {
+                  "label": "Starte Video bei",
+                  "description": "Den Zeitcode im Format M:SS angeben"
+                },
+                {
                   "label": "Videooptionen für den Startbildschirm",
                   "fields": [
                     {

--- a/language/es.json
+++ b/language/es.json
@@ -22,6 +22,10 @@
                   "description": "Información relacionada con los derechos de autor del video y de los elementos usados en el video."
                 },
                 {
+                  "label": "Start video at",
+                  "description": "Enter timecode in the format M:SS"
+                },
+                  {
                   "label": "Ajuste de interacciones",
                   "fields": [
                     {

--- a/language/fr.json
+++ b/language/fr.json
@@ -23,6 +23,10 @@
                   "description": "Informations sur le copyright de la vidéo et des éléments utilisés dans la vidéo."
                 },
                 {
+                  "label": "Start video at",
+                  "description": "Enter timecode in the format M:SS"
+                },				
+                {
                   "label": "Options de l'écran de lancement de la vidéo",
                   "fields": [
                     {

--- a/language/it.json
+++ b/language/it.json
@@ -23,6 +23,10 @@
                   "description": "Informazioni riguardanti i copyright del video e degli elementi utilizzati nel video."
                 },
                 {
+                  "label": "Start video at",
+                  "description": "Enter timecode in the format M:SS"
+                },				
+                {
                   "label": "Video start screen options",
                   "fields": [
                     {

--- a/language/nb.json
+++ b/language/nb.json
@@ -32,6 +32,10 @@
                   "description": "Informasjon om opphavsrett for videoen og andre elementer brukt i interaksjonene."
                 },
                 {
+                  "label": "Start video at",
+                  "description": "Enter timecode in the format M:SS"
+                },				
+                {
                   "englishLabel": "Video start screen options",
                   "label": "Video startskjerm innstillinger",
                   "fields": [

--- a/language/nn.json
+++ b/language/nn.json
@@ -23,6 +23,10 @@
                   "description": "Informasjon om opphavsrett for videoen og andre elementar brukt i interaksjonane."
                 },
                 {
+                  "label": "Start video at",
+                  "description": "Enter timecode in the format M:SS"
+                },				
+                {
                   "label": "Video startskjerm innstillinger",
                   "fields": [
                     {

--- a/language/zh.json
+++ b/language/zh.json
@@ -22,6 +22,10 @@
                   "description": "展示视频及其中所用元素的版权信息。"
                 },
                 {
+                  "label": "Start video at",
+                  "description": "Enter timecode in the format M:SS"
+                },				
+                {
                   "label": "首帧显示项",
                   "fields": [
                     {

--- a/scripts/interactive-video.js
+++ b/scripts/interactive-video.js
@@ -112,7 +112,13 @@ H5P.InteractiveVideo = (function ($, EventDispatcher, DragNBar, Interaction) {
       }
     }
 
-    var startAt = (self.previousState && self.previousState.progress) ? Math.floor(self.previousState.progress) : 0;
+    var startAt;
+    if (!!self.options.video.advancedSettings.startVideoAt) {
+      startAt = self.options.video.advancedSettings.startVideoAt;
+    }
+    else {
+      startAt = (self.previousState && self.previousState.progress) ? Math.floor(self.previousState.progress) : 0;
+    }
     // Start up the video player
     self.video = H5P.newRunnable({
       library: 'H5P.Video 1.2',

--- a/scripts/interactive-video.js
+++ b/scripts/interactive-video.js
@@ -12,6 +12,8 @@ H5P.InteractiveVideo = (function ($, EventDispatcher, DragNBar, Interaction) {
   function InteractiveVideo(params, id, contentData) {
     var self = this;
 
+	var startAt;
+
     // Inheritance
     H5P.EventDispatcher.call(self);
 
@@ -112,13 +114,12 @@ H5P.InteractiveVideo = (function ($, EventDispatcher, DragNBar, Interaction) {
       }
     }
 
-    var startAt;
-    if (!!self.options.video.advancedSettings.startVideoAt) {
+	// set start time
+    startAt = (self.previousState && self.previousState.progress) ? Math.floor(self.previousState.progress) : 0;	
+    if (startAt === 0 && !!self.options.video.advancedSettings.startVideoAt) {
       startAt = self.options.video.advancedSettings.startVideoAt;
     }
-    else {
-      startAt = (self.previousState && self.previousState.progress) ? Math.floor(self.previousState.progress) : 0;
-    }
+
     // Start up the video player
     self.video = H5P.newRunnable({
       library: 'H5P.Video 1.2',

--- a/semantics.json
+++ b/semantics.json
@@ -45,6 +45,14 @@
                 ]
               },
               {
+                "name": "startVideoAt",
+                "type": "number",
+                "widget": "timecode",
+                "label": "Start video at",
+                "optional": true,
+                "description": "Enter timecode in the format M:SS"
+              },
+              {
                 "name": "startScreenOptions",
                 "type": "group",
                 "label": "Video start screen options",


### PR DESCRIPTION
I added an option in _semantics.json_ (advancedSettings) allowing you to set an optional start time for the video. I was asked for this feature several times, so I thought: Why not?