### PR TITLE
add functionality for custom quality labels

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -17,7 +17,8 @@
             "type": "video",
             "label": "Video files",
             "importance": "high",
-            "description": "Select the video files you wish to use in your interactive video. To ensure maximum support in browsers at least add a version of the video in webm and mp4 formats."
+            "description": "Select the video files you wish to use in your interactive video. To ensure maximum support in browsers at least add a version of the video in webm and mp4 formats.",
+            "extraAttributes": ["metadata"]
           },
           {
             "name": "startScreenOptions",


### PR DESCRIPTION
implements [custom video quality labels as requested and discussed in the forum](https://h5p.org/node/44733)

requires [pull request for h5p-editor-php-library](https://github.com/h5p/h5p-editor-php-library/pull/29) and [pull request for h5p-video](https://github.com/h5p/h5p-video/pull/12)