### PR TITLE
Fix order of questions listed on submit screen

### DIFF
--- a/src/scripts/endscreen.js
+++ b/src/scripts/endscreen.js
@@ -234,7 +234,7 @@ class Endscreen extends H5P.EventDispatcher {
     // Filter for interactions that have been answered and sort chronologically
     this.answered = interactions
       .filter(interaction => interaction.getProgress() !== undefined)
-      .sort((a, b) => a.getDuration().from > b.getDuration().from);
+      .sort((a, b) => a.getDuration().from - b.getDuration().from);
 
     this.$endscreenBottomTable.empty();
 


### PR DESCRIPTION
When merged in, the questions will be sorted according to the order of their appearance in the video again.