### PR TITLE
Add option to disable submit button until video ended

### DIFF
--- a/language/.en.json
+++ b/language/.en.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/ar.json
+++ b/language/ar.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/bg.json
+++ b/language/bg.json
@@ -433,6 +433,11 @@
           "description": "@answered ще бъде заменен с броя на отговорените въпроси."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Екран с информация за липсващите отговори на въпроси",
           "default": "Не сте отговорил на нито един въпрос"
         },

--- a/language/bn.json
+++ b/language/bn.json
@@ -433,6 +433,11 @@
           "description": "@answered র বদলে মোট উত্তর দেয়ার সংখ্যা দেখা যাবে।"
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "দাখিল স্ক্রিনে উত্তর না পাওয়া প্রশ্ন সম্পর্কে",
           "default": "আপনি প্রশ্নসমূহের উত্তর দেন নি।"
         },

--- a/language/bs.json
+++ b/language/bs.json
@@ -433,6 +433,11 @@
           "description": "@answered će biti zamijenjeno sa brojem odgovorenih pitanja."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "Niste odgovoritli ni na jedno pitanje."
         },

--- a/language/cs.json
+++ b/language/cs.json
@@ -433,6 +433,11 @@
           "description": "@answeredbude nahrazeno počtem zodpovězených otázek."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Informace obrazovky odpovědí pro chybějící odpovědi",
           "default": "Neodpověděli jste žádné otázky."
         },

--- a/language/da.json
+++ b/language/da.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/de.json
+++ b/language/de.json
@@ -433,6 +433,11 @@
           "description": "@answered wird durch die Anzahl der beantworteten Fragen ersetzt."
         },
         {
+          "label": "Text auf dem Einsendebildschirm, wenn noch nicht fertig",
+          "default": "Du kannst deine Ergebnisse nicht absenden, bevor das Video das Ende erreicht hat.",
+          "description": "Blendet den Button zum Ansenden der Ergebnisse aus, bis das Video das Ende erreicht hat."
+        },
+        {
           "label": "Einsendebildschirm: Hinweis bei fehlenden Antworten",
           "default": "Du hast noch keine Fragen beantwortet."
         },

--- a/language/el.json
+++ b/language/el.json
@@ -433,6 +433,11 @@
           "description": "Η μεταβλητή @answered θα αντικατασταθεί από τις ερωτήσεις που απαντήθηκαν."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Πληροφορία οθόνης υποβολής για απαντήσεις που λείπουν",
           "default": "Δεν έχεις απαντήσει σε καμμία ερώτηση."
         },

--- a/language/es-mx.json
+++ b/language/es-mx.json
@@ -433,6 +433,11 @@
           "description": "@answered será reemplazada por el número de preguntas respondidas."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Información de pantalla para respuestas faltantes",
           "default": "Usted no ha respondido ninguna pregunta."
         },

--- a/language/es.json
+++ b/language/es.json
@@ -433,6 +433,11 @@
           "description": "@answered será reemplazada por el número de preguntas respondidas."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Información de pantalla para respuestas faltantes",
           "default": "Usted no ha respondido ninguna pregunta."
         },

--- a/language/et.json
+++ b/language/et.json
@@ -433,6 +433,11 @@
           "description": "@answered asendatakse vastatud küsimuste arvuga."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Esita kuva teave puuduvatele vastustele",
           "default": "Sa ei ole vastanud ühelegi küsimusele."
         },

--- a/language/eu.json
+++ b/language/eu.json
@@ -433,6 +433,11 @@
           "description": "@answered aldagaian erantzundako galdera kopurua bistaratuko da."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Bidali erantzun gabeko galderen berri ematen duen pantailaren informazioa",
           "default": "Ez duzu hainbat galdera erantzun."
         },

--- a/language/fa.json
+++ b/language/fa.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/fi.json
+++ b/language/fi.json
@@ -433,6 +433,11 @@
           "description": "muuttuja @answered korvataan automaattisesti vastattujen kysymysten lukumäärällä"
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Yhteenvetonäkymän teksti vastaamattomille kysymyksille",
           "default": "Et ole vielä vastannut yhteenkään kysymykseen"
         },

--- a/language/fr.json
+++ b/language/fr.json
@@ -433,6 +433,11 @@
           "description": "@answered sera remplacé par le nombre de questions pour lesquelles une réponse a été donnée."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Écran de remise pour réponses manquantes",
           "default": "Vous n'avez répondu à aucune question."
         },

--- a/language/hr.json
+++ b/language/hr.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/hu.json
+++ b/language/hu.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/it.json
+++ b/language/it.json
@@ -433,6 +433,11 @@
           "description": "@answered sarà sostituito dal numero di domande con risposta"
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Invia la schermata di informazioni per le risposte mancanti",
           "default": "Non hai risposto a nessuna domanda"
         },

--- a/language/ja.json
+++ b/language/ja.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/nb.json
+++ b/language/nb.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/nl.json
+++ b/language/nl.json
@@ -433,6 +433,11 @@
           "description": "@answered zal worden vervangen door het aantal beantwoorde vragen."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Verzend scherminformatie voor ontbrekende antwoorden",
           "default": "Je hebt geen vragen beantwoord."
         },

--- a/language/nn.json
+++ b/language/nn.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "Du har ikkje svart på nokon spørsmål."
         },

--- a/language/pl.json
+++ b/language/pl.json
@@ -433,6 +433,11 @@
           "description": "@answered zostanie zamienione na liczbę rozwiązanych zadań."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Ekran wyników: komunikat o braku odpowiedzi",
           "default": "Żadne z zadań nie zostało rozwiązane."
         },

--- a/language/pt-br.json
+++ b/language/pt-br.json
@@ -433,6 +433,11 @@
           "description": "@answered será substituído pelo número de questões respondidas."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Informação da tela de submissão para ausência de respostas",
           "default": "Você não respondeu todas as questões."
         },

--- a/language/pt.json
+++ b/language/pt.json
@@ -433,6 +433,11 @@
           "description": "@answered será substituído pelo número de perguntas respondidas."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Informação do ecrã de submissão para a ausência de respostas",
           "default": "Não respondeu a qualquer pergunta."
         },

--- a/language/ru.json
+++ b/language/ru.json
@@ -433,6 +433,11 @@
           "description": "@answered будет заменено на количество отвеченных вопросов."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Отправить информацию на экран для пропущенных ответов",
           "default": "Вы не ответили ни на один вопрос."
         },

--- a/language/sl.json
+++ b/language/sl.json
@@ -433,6 +433,11 @@
           "description": "@answered je spremenljivka."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Sporočilo Zaslona za potrditev odgovorov o manjkajočem odgovoru",
           "default": "Ni odgovorov na vprašanja."
         },

--- a/language/sma.json
+++ b/language/sma.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/sme.json
+++ b/language/sme.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/smj.json
+++ b/language/smj.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/language/sv.json
+++ b/language/sv.json
@@ -433,6 +433,11 @@
           "description": "@answered kommer ersättas med antalet frågor."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Inlämningssida för saknade svar",
           "default": "Du har inte svarat på några frågor."
         },

--- a/language/tr.json
+++ b/language/tr.json
@@ -433,6 +433,11 @@
           "description": "@answered , will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Eksik cevaplar için gönderi ekranı bilgisi",
           "default": "Heniz bir soru cevaplamadınız."
         },

--- a/language/zh-hans.json
+++ b/language/zh-hans.json
@@ -433,6 +433,11 @@
           "description": "@answered 为已回答数"
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "提交画面中的未回答讯息文字",
           "default": "你没有回答任何问题。"
         },

--- a/language/zh-hant.json
+++ b/language/zh-hant.json
@@ -433,6 +433,11 @@
           "description": "@answered 為已回答數"
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "提交畫面中的未回答訊息文字",
           "default": "你沒有回答任何問題。"
         },

--- a/language/zh-tw.json
+++ b/language/zh-tw.json
@@ -433,6 +433,11 @@
           "description": "@answered will be replaced by the number of answered questions."
         },
         {
+          "label": "Submit screen information for not finished",
+          "default": "You cannot submit your answers before the video has reached the end.",
+          "description": "Will disable the submit button until the video has reached the end."
+        },
+        {
           "label": "Submit screen information for missing answers",
           "default": "You have not answered any questions."
         },

--- a/semantics.json
+++ b/semantics.json
@@ -724,6 +724,14 @@
         "description": "Enabling this options will disable user video navigation through default controls."
       },
       {
+        "name": "disableSubmitButton",
+        "type": "boolean",
+        "default": false,
+        "label": "Disable submit button",
+        "importance": "low",
+        "description": "Enabling this option will disable the submit button until the video finished playing."
+      },
+      {
         "name": "deactivateSound",
         "type": "boolean",
         "default": false,
@@ -1005,6 +1013,15 @@
         "importance": "low",
         "default": "You have answered @answered questions, click below to submit your answers.",
         "description": "@answered will be replaced by the number of answered questions.",
+        "optional": true
+      },
+      {
+        "name": "endcardInformationNotFinished",
+        "type": "text",
+        "label": "Submit screen information for not finished",
+        "importance": "low",
+        "default": "You cannot submit your answers before the video has reached the end.",
+        "description": "Will disable the submit button until the video has reached the end.",
         "optional": true
       },
       {

--- a/src/scripts/endscreen.js
+++ b/src/scripts/endscreen.js
@@ -35,6 +35,7 @@ class Endscreen extends H5P.EventDispatcher {
       information: 'You have answered @answered questions, click below to submit your answers.',
       informationNoAnswers: 'You have not answered any questions.',
       informationMustHaveAnswer: 'You have to answer at least one question before you can submit your answers.',
+      informationNotFinished: 'You cannot submit your answers before the video has reached the end.',
       submitButton: 'Submit Answers',
       submitMessage: 'Your answers have been submitted!',
       tableRowAnswered: 'Answered questions',
@@ -255,12 +256,15 @@ class Endscreen extends H5P.EventDispatcher {
     if (number === 0) {
       this.$endscreenIntroductionText.html(`<div class="${ENDSCREEN_STYLE_BASE}-bold-text">${this.l10n.informationNoAnswers}</div><div>${this.l10n.informationMustHaveAnswer}<div>`);
     }
+    else if (this.parent.disableSubmitButton) {
+      this.$endscreenIntroductionText.html(this.l10n.informationNotFinished);
+    }
     else {
       this.$endscreenIntroductionText.html(this.l10n.information.replace('@answered', number));
     }
 
     // Only show submit button (again) if there are answered interactions
-    if (number > 0) {
+    if (number > 0 && !this.parent.disableSubmitButton) {
       this.$submitButtonContainer.removeClass(ENDSCREEN_STYLE_BUTTON_HIDDEN);
     }
   }

--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -107,6 +107,7 @@ function InteractiveVideo(params, id, contentData) {
     self.showRewind10 = (params.override.showRewind10 !== undefined ? params.override.showRewind10 : false);
     self.showBookmarksmenuOnLoad = (params.override.showBookmarksmenuOnLoad !== undefined ? params.override.showBookmarksmenuOnLoad : false);
     self.preventSkipping = params.override.preventSkipping || false;
+    self.disableSubmitButton = params.override.disableSubmitButton || false;
     self.deactivateSound = params.override.deactivateSound || false;
   }
   // Translated UI text defaults
@@ -308,6 +309,11 @@ function InteractiveVideo(params, id, contentData) {
       switch (state) {
         case H5P.Video.ENDED: {
           self.currentState = H5P.Video.ENDED;
+
+          // Make sure submit button is now enabled
+          self.disableSubmitButton = false;
+          self.endscreen.update(self.interactions);
+
           self.controls.$play
             .addClass('h5p-pause')
             .attr('aria-label', self.l10n.play);
@@ -1229,6 +1235,7 @@ InteractiveVideo.prototype.addBubbles = function () {
         information: this.l10n.endcardInformation,
         informationNoAnswers: this.l10n.endcardInformationNoAnswers,
         informationMustHaveAnswer: this.l10n.endcardInformationMustHaveAnswer,
+        informationNotFinished: this.l10n.endcardInformationNotFinished,
         submitButton: this.l10n.endcardSubmitButton,
         submitMessage: this.l10n.endcardSubmitMessage,
         tableRowAnswered: this.l10n.endcardTableRowAnswered,


### PR DESCRIPTION
This feature was requested at least twice, see https://h5p.org/node/318508 and https://h5p.org/comment/35387

It allows authors to disable the submit button on the submit screen until the video has ended playing.