### PR TITLE
feature/captions-default-to-off

### DIFF
--- a/semantics.json
+++ b/semantics.json
@@ -138,7 +138,7 @@
                 "name": "defaultTrackLabel",
                 "type": "text",
                 "label": "Default text track",
-                "description": "If left empty or not matching any of the text tracks the first text track will be used as the default.",
+                "description": "If left empty or not matching any of the text tracks, the default track will be set to Off",
                 "importance": "low",
                 "optional": true
               }

--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -590,6 +590,8 @@ InteractiveVideo.prototype.setCaptionTracks = function (tracks) {
     currentTrack = tracks[0];
   }
 
+  self.video.setCaptionsTrack(null);
+
   // Create new track selector
   self.captionsTrackSelector = new SelectorControl('captions', tracks, currentTrack, 'menuitemradio', self.l10n, self.contentId);
 


### PR DESCRIPTION
This change applies a fix to the captions editor of interactive-video, in which leaving the "Default Text Track" empty forces the captions to be set to "Off" once the video is played. The incentive for this change is as follows:

- Before this change, leaving the "Default Text Track" textbox empty would default the captions to the first text track in the tracks array. For example, if you had English as the first track and Spanish as the second, the captions would default to English if left empty, or even in the case "Off" was typed in to the text box
- This has forced users to add an "empty" text track to their subtitles array in order to get the video to default to off, which is undesired.
- The semantics have been changed so that the user can still type in a label they want the captions to default to, as long as it is in the tracks array. However, if they do not type in anything, it will default to "Off" automatically. 

This issue is well documented in the h5p discussion forum, linked [here](https://h5p.org/node/212899). This change addresses the issues discussed and would assist many users requesting this feature.