### PR TITLE
Fix muted videos on mobile

### DIFF
--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -2159,7 +2159,7 @@ InteractiveVideo.prototype.attachControls = function ($wrapper) {
     self.video.mute();
   }
 
-  if (self.video.isMuted()) {
+  if (self.video.isMuted() && self.controls.$volume) {
     // Toggle initial mute button state
     self.controls.$volume
       .addClass('h5p-muted')


### PR DESCRIPTION
Currently, when running on Android or iPad, no volume button is created but referenced if the video is set to run muted, leading to a crash.

When merged in, will check for the button being present before altering it.