### PR TITLE
HFP-3646 Fix skipping message overflow

### DIFF
--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -1904,7 +1904,7 @@ InteractiveVideo.prototype.attachControls = function ($wrapper) {
   var $right = $('<div/>', {'class': 'h5p-controls-right', appendTo: $wrapper});
 
   if (self.preventSkippingMode === 'both') {
-    self.setDisabled($slider);
+    self.setDisabled(self.$sliderContainer);
   }
 
   // Keep track of all controls

--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -1571,6 +1571,34 @@ InteractiveVideo.prototype.showPreventSkippingMessage = function (offset = {}, m
     });
   }
 
+  // Limit message width to current video width
+  const messagePaddingX = self.$preventSkippingMessage.innerWidth() -
+    self.$preventSkippingMessage.width();
+
+  self.$preventSkippingMessage.css(
+    'max-width', `${self.$videoWrapper.width() - messagePaddingX}px`
+  );
+
+  // Correct x offset if element overflows content container
+  const messageTranslateX = parseFloat(
+    self.$preventSkippingMessage.css('transform').split(',')[4] ?? 0
+  );
+
+  const sliderOffset = self.$sliderContainer.get(0).offsetLeft +
+    self.controls.$slider.get(0).offsetLeft +
+    offset.x +
+    messageTranslateX;
+
+  const messageOuterRightCornerX = sliderOffset +
+    self.$preventSkippingMessage.outerWidth()
+
+  const overflow = Math.max(
+    0, messageOuterRightCornerX - self.$container.width()
+  );
+  offset.x -= overflow;
+
+  // Prevent message pointing to slider position, because message is displaced
+  self.$preventSkippingMessage.toggleClass('h5p-overflow', overflow > 0);
 
   // Move element to offset position
   self.$preventSkippingMessage.css('left', offset.x);
@@ -1863,7 +1891,7 @@ InteractiveVideo.prototype.attachControls = function ($wrapper) {
 
   // The controls consist of four different sections:
   var $left = $('<div/>', {'class': 'h5p-controls-left', appendTo: $wrapper});
-  var $slider = $('<div/>', {'class': 'h5p-control h5p-slider', appendTo: $wrapper});
+  self.$sliderContainer = $('<div/>', {'class': 'h5p-control h5p-slider', appendTo: $wrapper});
   // True will be replaced by boolean variable, e.g. endScreenAvailable
 
   if (self.hasStar) {
@@ -2318,19 +2346,19 @@ InteractiveVideo.prototype.attachControls = function ($wrapper) {
 
   self.controls.$bookmarksContainer = $('<div/>', {
     'class': 'h5p-bookmarks-container',
-    appendTo: $slider
+    appendTo: self.$sliderContainer
   });
 
   self.controls.$endscreensContainer = $('<div/>', {
     'class': 'h5p-endscreens-container',
-    appendTo: $slider
+    appendTo: self.$sliderContainer
   });
 
   // Add seekbar/timeline
   self.hasPlayPromise = false;
   self.hasQueuedPause = false;
   self.delayed = false;
-  self.controls.$slider = $('<div/>', {appendTo: $slider}).slider({
+  self.controls.$slider = $('<div/>', {appendTo: self.$sliderContainer}).slider({
     value: 0,
     step: 0.01,
     orientation: 'horizontal',
@@ -2501,7 +2529,7 @@ InteractiveVideo.prototype.attachControls = function ($wrapper) {
   });
 
   // Append after ui slider
-  self.controls.$interactionsContainer.appendTo($slider);
+  self.controls.$interactionsContainer.appendTo(self.$sliderContainer);
 
   // Disable slider
   if (self.preventSkippingMode === 'both') {

--- a/src/styles/interactive-video.css
+++ b/src/styles/interactive-video.css
@@ -1019,11 +1019,15 @@
   background: rgba(44, 44, 44, 0.8);
   opacity: 0;
   visibility: hidden;
-  max-width: 300px;
   -webkit-transition: visibility 0s 0.2s, opacity 0.2s;
   -moz-transition: visibility 0s 0.2s, opacity 0.2s;
   transition: visibility 0s 0.2s, opacity 0.2s;
   z-index: 10;
+}
+
+.h5p-interactive-video .h5p-bookmark-label,
+.h5p-interactive-video .h5p-endscreen-label {
+  max-width: 300px;
 }
 
 .h5p-interactive-video .h5p-prevent-skipping-message {
@@ -1032,16 +1036,11 @@
 }
 
 .h5p-interactive-video .h5p-prevent-skipping-message-text {
-  max-width: 17.5em;
   line-height: 30px;
 
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
-}
-
-.h5p-interactive-video.h5p-minimal .h5p-prevent-skipping-message-text {
-  max-width: 9.5em;
 }
 
 .h5p-interactive-video.h5p-fullscreen .h5p-prevent-skipping-message,
@@ -1075,6 +1074,10 @@
   border-top-color: rgba(44, 44, 44, 0.8);
   border-bottom: 0;
   top: 100%;
+}
+
+.h5p-interactive-video .h5p-prevent-skipping-message.h5p-overflow:after {
+  opacity: 0;
 }
 
 .h5p-interactive-video.h5p-fullscreen .h5p-prevent-skipping-message:after,
@@ -1223,7 +1226,7 @@
   box-sizing: border-box;
   -moz-box-sizing: border-box;
 }
-.h5p-interactive-video .h5p-dialog-close, 
+.h5p-interactive-video .h5p-dialog-close,
 .h5p-interactive-video .h5p-dialog[data-lib="H5P.SingleChoiceSet"] .h5p-dialog-titlebar .h5p-sc-sound-control {
   position: absolute;
   top: 0.25em;


### PR DESCRIPTION
When merged in, will
- remove previously defined fixed maximum width for skipping messages,
- ensure that skipping message does not overflow video container left or right,
- hide message pointer that would point towards click position on slider if skipping message needed to be displaced, and
- still truncate text with ellipses if text is too long to fit into video container.