### PR TITLE
Add package-lock.json to .h5pignore

### DIFF
--- a/.h5pignore
+++ b/.h5pignore
@@ -16,5 +16,6 @@ webpack.dev.config.js
 README.md
 CONTRIBUTING.md
 package.json
+package-lock.json
 worknotes
 crowdin.yml


### PR DESCRIPTION
When merged in, will use 306.5kB less storage space (uncompressed) in the library's directory and in content files! ;-)