### PR TITLE
HFP-3934 Fix initial slider tabindex

### DIFF
--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -302,7 +302,7 @@ function InteractiveVideo(params, id, contentData) {
       self.loaded();
 
       if (!self.controls) {
-        // Make sure that controls are added before setting time 
+        // Make sure that controls are added before setting time
         self.addControls();
         self.trigger('resize');
       }
@@ -2387,7 +2387,7 @@ InteractiveVideo.prototype.attachControls = function ($wrapper) {
         .attr('aria-valuetext', InteractiveVideo.formatTimeForA11y(0, self.l10n))
         .attr('aria-valuenow', '0')
         .attr('aria-label', self.l10n.videoProgressBar)
-        .attr('tabindex', '-1');
+        .attr('tabindex', '0');
 
       if (self.preventSkippingMode === 'both') {
         self.setDisabled($handle).attr('aria-hidden', 'true');


### PR DESCRIPTION
When merged in, will set the initial slider tabindex to 0 instead of -1.