### PR TITLE
VA-931 Remove overflow exception for SCS and harmonize table font size

### DIFF
--- a/src/styles/interactive-video.css
+++ b/src/styles/interactive-video.css
@@ -1364,7 +1364,7 @@
 
   /* Necessary for backwards compatibility */
   table {
-    font-size: 0.875em;
+    font-size: 0.765625em;
   }
 }
 .h5p-interactive-video .h5p-table figure.table {


### PR DESCRIPTION
When merge in, will remove the height/overflow exception for Single Choice Set, so posters will get a scrollbar on overflow.

Also, will move the extra modifier that's missing for table font sizes to the view where it is not used. Requires https://github.com/h5p/h5p-editor-interactive-video/pull/97