### PR TITLE
Fix Norwegian translation files

### DIFF
--- a/language/nb.json
+++ b/language/nb.json
@@ -61,7 +61,6 @@
                       },
                       {
                         "label": "Kildespråk",
-                        "default": "en",
                         "description": "Må være en gyldig BCP 47-språktagg. Hvis \"Undertekster\" er valgt, må du definere språket i tekstsporet."
                       },
                       {
@@ -164,8 +163,7 @@
                     "label": "Visuelle effekter",
                     "fields": [
                       {
-                        "label": "Bakgrunnsfarge",
-                        "default": "rgb(255, 255, 255)"
+                        "label": "Bakgrunnsfarge"
                       },
                       {
                         "label": "Skygge",

--- a/language/nn.json
+++ b/language/nn.json
@@ -61,7 +61,6 @@
                       },
                       {
                         "label": "Kjeldespråk",
-                        "default": "en",
                         "description": "Må vere ein gyldig BCP 47-språktagg. Dersom \"Undertekstar\" er valt, må du definere språket i tekstsporet."
                       },
                       {
@@ -164,8 +163,7 @@
                     "label": "Visuelle effektar",
                     "fields": [
                       {
-                        "label": "Bakgrunnsfarge",
-                        "default": "rgb(255, 255, 255)"
+                        "label": "Bakgrunnsfarge"
                       },
                       {
                         "label": "Skygge",


### PR DESCRIPTION
When merged in, will remove the invalid default values that were introduced by https://github.com/h5p/h5p-interactive-video/pull/343.

Default values that are language codes or colors should not be inside translation files.