### PR TITLE
Improve caption track selection on load

### DIFF
--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -614,15 +614,17 @@ InteractiveVideo.prototype.setCaptionTracks = function (tracks) {
   }, undefined);
 
   // Determine current captions track
-  let currentTrack = defaultTrack || self.video.getCaptionsTrack();
+  let currentTrack = self.previousState?.captionTrack || defaultTrack || self.video.getCaptionsTrack();
 
-  if (!currentTrack) {
-    // Set default off when no track is selected
-    currentTrack = tracks[0];
+  function setCurrentTrack(track) {
+    self.currentCaptionTrack = track;
+    self.video.setCaptionsTrack(track.value === 'off' ? null : track);
   }
+  // Set default off when no track is selected
+  setCurrentTrack(currentTrack || tracks[0]);
 
   // Create new track selector
-  self.captionsTrackSelector = new SelectorControl('captions', tracks, currentTrack, 'menuitemradio', self.l10n, self.contentId);
+  self.captionsTrackSelector = new SelectorControl('captions', tracks, self.currentCaptionTrack, 'menuitemradio', self.l10n, self.contentId);
 
   // Insert popup and button
   self.controls.$captionsButton = $(self.captionsTrackSelector.control);
@@ -638,7 +640,7 @@ InteractiveVideo.prototype.setCaptionTracks = function (tracks) {
   self.controls.$overlayButtons = self.controls.$overlayButtons.add(self.captionsTrackSelector.overlayControl);
 
   self.captionsTrackSelector.on('select', function (event) {
-    self.video.setCaptionsTrack(event.data.value === 'off' ? null : event.data);
+    setCurrentTrack(event.data);
   });
   self.captionsTrackSelector.on('close', function () {
     self.controls.$overlayButtons.removeClass('h5p-hide');
@@ -671,6 +673,7 @@ InteractiveVideo.prototype.getCurrentState = function () {
     progress: self.currentTime,
     maxTimeReached: this.maxTimeReached || null,
     answers: [],
+    captionTrack: self.currentCaptionTrack,
     interactionsProgress: self.interactions
       .slice()
       .sort((a, b) => a.getDuration().from - b.getDuration().from)

--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -12,6 +12,7 @@ const $ = H5P.jQuery;
 const SECONDS_IN_MINUTE = 60;
 const MINUTES_IN_HOUR = 60;
 const KEYBOARD_STEP_LENGTH_SECONDS = 5;
+const LS_CAPTION_KEY = 'h5p.interactivevideo.captiontrack'
 
 /**
  * @typedef {Object} InteractiveVideoParameters
@@ -614,10 +615,20 @@ InteractiveVideo.prototype.setCaptionTracks = function (tracks) {
   }, undefined);
 
   // Determine current captions track.  If none saved and none default, start disabled
-  let currentTrack = self.previousState?.captionTrack || defaultTrack || tracks[0];
+  let savedTrack = null;
+  try {
+    savedTrack = JSON.parse(localStorage.getItem(LS_CAPTION_KEY));
+  } catch(error) {
+    console.log('Failed to load caption track preference.');
+  }
+  if (!(savedTrack && tracks.some(t => t.label === savedTrack.label && t.value === savedTrack.value))) {
+    savedTrack = null;
+  }
+  let currentTrack = self.previousState?.captionTrack || savedTrack || defaultTrack || tracks[0];
 
   function setCurrentTrack(track) {
     self.currentCaptionTrack = track;
+    localStorage.setItem(LS_CAPTION_KEY, JSON.stringify(track));
     self.video.setCaptionsTrack(track.value === 'off' ? null : track);
   }
   setCurrentTrack(currentTrack);

--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -613,15 +613,14 @@ InteractiveVideo.prototype.setCaptionTracks = function (tracks) {
     return (result === undefined && defaultTrackLabel && current.label === defaultTrackLabel) ? current : result;
   }, undefined);
 
-  // Determine current captions track
-  let currentTrack = self.previousState?.captionTrack || defaultTrack || self.video.getCaptionsTrack();
+  // Determine current captions track.  If none saved and none default, start disabled
+  let currentTrack = self.previousState?.captionTrack || defaultTrack || tracks[0];
 
   function setCurrentTrack(track) {
     self.currentCaptionTrack = track;
     self.video.setCaptionsTrack(track.value === 'off' ? null : track);
   }
-  // Set default off when no track is selected
-  setCurrentTrack(currentTrack || tracks[0]);
+  setCurrentTrack(currentTrack);
 
   // Create new track selector
   self.captionsTrackSelector = new SelectorControl('captions', tracks, self.currentCaptionTrack, 'menuitemradio', self.l10n, self.contentId);


### PR DESCRIPTION
This PR makes several changes to the selection of the caption track when the element is loaded.  I've grouped them all into one, since they feel related.  But if you'd like to consider them independently , let me know and I'll separate them.

1. Store the selected caption track in the user state, and use that, if it exists, when the element is loaded.  That way, the user will have their choice of caption track remembered when the return to the video.
2. Don't turn on the first caption track in the absence of a default track.  As far as I could tell, there was no way to configure the element to start with captions off if there was at least one caption track.  If a track is marked as default, it will be enabled as before, but if none are marked default, the captions will be off by default.
3. Store the user's caption track choice in localStorage.  Use this to select a caption track if the full option (label and value) is an available track.  This allows a user to make a choice of caption tracks at the beginning of a series of videos and have that choice respected throughout the entire series.  Being in localStorage, this will only persist on the current device; I don't know if there's some global H5P settings object where this could be stored instead?

I've set the priority to be
>    user state > localStorage > default track > no caption track

I think it could also be reasonable to swap localStorage and the default track, so that the localStorage option only activates when there isn't a default track specified.