### PR TITLE
Feature: 360 degree video support

### DIFF
--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -2826,6 +2826,17 @@ InteractiveVideo.prototype.add360MouseOverlay = function () {
     };
   });
 
+  // Touch events require slightly different logic than mouse events.
+  $('.h5p-video-360-overlay').on('touchstart', (event) => {
+    event.preventDefault();
+  
+    self.user360Draging = true;
+    self.user360DragingLastLocation = {
+      x: event.touches[0].clientX,
+      y: event.touches[0].clientY,
+    };
+  });
+
   $(window).on('mousemove', async (event) => {
     // Prevent event overflow by waiting atleast 10ms between successful updates.
     if(Date.now() - self.last360UpdateTime < 10) {
@@ -2866,7 +2877,48 @@ InteractiveVideo.prototype.add360MouseOverlay = function () {
     self.last360UpdateTime = Date.now();
   });
 
-  $(window).on('mouseup', (event) => {
+  // Touch events require slightly different logic than mouse events.
+  $(window).on('touchmove', async (event) => {
+    // Prevent event overflow by waiting atleast 10ms between successful updates.
+    if(Date.now() - self.last360UpdateTime < 10) {
+      return;
+    }
+
+    // If user is not currently dragging or drag has been stopped, return;
+    if(!self.user360Draging || self.user360DragingLastLocation === null) {
+      return;
+    }
+
+    let current360ViewProps = await self.video.get360ViewProperties() ?? {
+      yaw: 0,
+      pitch: 0,
+      roll: 0,
+      fov: 75
+    };
+
+    let diffX = event.touches[0].clientX - self.user360DragingLastLocation.x;
+    let diffY = event.touches[0].clientY - self.user360DragingLastLocation.y;
+    let sensitivity = current360ViewProps.fov / 500;
+
+    let normalizedYaw = Math.round((current360ViewProps.yaw - (diffX * sensitivity)) * 1e5) / 1e5;
+    normalizedYaw = Math.max(0, Math.min(360, normalizedYaw % 360 < 0 ? (normalizedYaw + 360) : normalizedYaw));
+
+    await self.video.set360ViewProperties({
+      yaw: normalizedYaw,
+      pitch: Math.max(-90, Math.min(90, (current360ViewProps.pitch + (diffY * sensitivity)))),
+      roll: current360ViewProps.roll,
+      fov: current360ViewProps.fov
+    });
+
+    self.user360DragingLastLocation = {
+      x: event.touches[0].clientX,
+      y: event.touches[0].clientY
+    };
+
+    self.last360UpdateTime = Date.now();
+  });
+
+  $(window).on('mouseup touchcancel touchend', (event) => {
     self.user360Draging = false;
   });
 };

--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -226,7 +226,7 @@ function InteractiveVideo(params, id, contentData) {
   // 360 video props.
   this.user360Draging = false;
   this.user360DragingLastLocation = null;
-  this.last360UpdateTime = 0;
+  this.is360EventSlotAvailable = true;
 
   /**
    * Keep track if the video source is loaded.
@@ -2838,8 +2838,8 @@ InteractiveVideo.prototype.add360MouseOverlay = function () {
   });
 
   $(window).on('mousemove', async (event) => {
-    // Prevent event overflow by waiting atleast 10ms between successful updates.
-    if(Date.now() - self.last360UpdateTime < 10) {
+    // Prevent event overflow.
+    if(!self.is360EventSlotAvailable) {
       return;
     }
 
@@ -2847,6 +2847,8 @@ InteractiveVideo.prototype.add360MouseOverlay = function () {
     if(!self.user360Draging || self.user360DragingLastLocation === null) {
       return;
     }
+
+    self.is360EventSlotAvailable = false;
 
     let current360ViewProps = await self.video.get360ViewProperties() ?? {
       yaw: 0,
@@ -2874,13 +2876,15 @@ InteractiveVideo.prototype.add360MouseOverlay = function () {
       y: event.clientY
     };
 
-    self.last360UpdateTime = Date.now();
+    setTimeout(() => {
+      self.is360EventSlotAvailable = true;
+    }, 10);
   });
 
   // Touch events require slightly different logic than mouse events.
   $(window).on('touchmove', async (event) => {
-    // Prevent event overflow by waiting atleast 10ms between successful updates.
-    if(Date.now() - self.last360UpdateTime < 10) {
+    // Prevent event overflow.
+    if(!self.is360EventSlotAvailable) {
       return;
     }
 
@@ -2888,6 +2892,8 @@ InteractiveVideo.prototype.add360MouseOverlay = function () {
     if(!self.user360Draging || self.user360DragingLastLocation === null) {
       return;
     }
+
+    self.is360EventSlotAvailable = false;
 
     let current360ViewProps = await self.video.get360ViewProperties() ?? {
       yaw: 0,
@@ -2915,11 +2921,14 @@ InteractiveVideo.prototype.add360MouseOverlay = function () {
       y: event.touches[0].clientY
     };
 
-    self.last360UpdateTime = Date.now();
+    setTimeout(() => {
+      self.is360EventSlotAvailable = true;
+    }, 10);
   });
 
   $(window).on('mouseup touchcancel touchend', (event) => {
     self.user360Draging = false;
+    self.is360EventSlotAvailable = true;
   });
 };
 

--- a/src/scripts/interactive-video.js
+++ b/src/scripts/interactive-video.js
@@ -223,6 +223,11 @@ function InteractiveVideo(params, id, contentData) {
   this.fontSize = 16;
   this.width = 640; // parseInt($container.css('width')); // Get width in px
 
+  // 360 video props.
+  this.user360Draging = false;
+  this.user360DragingLastLocation = null;
+  this.last360UpdateTime = 0;
+
   /**
    * Keep track if the video source is loaded.
    * @private
@@ -365,6 +370,12 @@ function InteractiveVideo(params, id, contentData) {
             self.addQualityChooser();
 
             self.addPlaybackRateChooser();
+
+            // If active handler supports 360 controls and current video is 360 video,
+            // create overlay(s) for mouse event capture and register events.
+            if(self.video.supports360Controls() && self.video.is360()) {
+              self.add360MouseOverlay();
+            }
 
             // Make sure splash screen is removed.
             self.removeSplash();
@@ -2771,6 +2782,93 @@ InteractiveVideo.prototype.updatePlaybackRate = function (rate) {
   else {
     self.controls.$playbackRateButton.click();
   }
+};
+
+InteractiveVideo.prototype.add360MouseOverlay = function () {
+  var self = this;
+
+  // This is quite dumb, however, it may be the only way to do it.
+  // Event listners can not be added to embedded iFrames. The only way to capture
+  // events on top of an iFrame is by using a transparent overlay <div> element.
+  // However, both YouTube and Vimeo have existing native UI elements in their players,
+  // which become unclickable if an overlay is present. The solution? Build the overlay
+  // out of multiple <div> elements, that avoid the existing player UI.
+  let overlayTemplate = self.video.get360OverlayTemplate();
+
+  if(overlayTemplate !== null) {
+    overlayTemplate.forEach((templatePart) => {
+      let e = $(document.createElement('div'));
+      e.attr('class', 'h5p-video-360-overlay');
+      e.css('position', 'absolute');
+
+      Object.keys(templatePart).forEach((key) => {
+        e.css(key, templatePart[key]);
+      });
+
+      e.appendTo(self.$videoWrapper);
+    });
+  } else {
+    let e = $(document.createElement('div'));
+    e.attr('class', 'h5p-video-360-overlay');
+    e.css('position', 'absolute');
+    e.css('left', 0);
+    e.css('top', 0)
+    e.css('height', '100%'),
+    e.css('width', '100%');
+    e.appendTo(self.$videoWrapper);
+  }
+
+  $('.h5p-video-360-overlay').on('mousedown', (event) => {
+    self.user360Draging = true;
+    self.user360DragingLastLocation = {
+      x: event.clientX,
+      y: event.clientY,
+    };
+  });
+
+  $(window).on('mousemove', async (event) => {
+    // Prevent event overflow by waiting atleast 10ms between successful updates.
+    if(Date.now() - self.last360UpdateTime < 10) {
+      return;
+    }
+
+    // If user is not currently dragging or drag has been stopped, return;
+    if(!self.user360Draging || self.user360DragingLastLocation === null) {
+      return;
+    }
+
+    let current360ViewProps = await self.video.get360ViewProperties() ?? {
+      yaw: 0,
+      pitch: 0,
+      roll: 0,
+      fov: 75
+    };
+
+    let diffX = event.clientX - self.user360DragingLastLocation.x;
+    let diffY = event.clientY - self.user360DragingLastLocation.y;
+    let sensitivity = current360ViewProps.fov / 500;
+
+    let normalizedYaw = Math.round((current360ViewProps.yaw - (diffX * sensitivity)) * 1e5) / 1e5;
+    normalizedYaw = Math.max(0, Math.min(360, normalizedYaw % 360 < 0 ? (normalizedYaw + 360) : normalizedYaw));
+
+    await self.video.set360ViewProperties({
+      yaw: normalizedYaw,
+      pitch: Math.max(-90, Math.min(90, (current360ViewProps.pitch + (diffY * sensitivity)))),
+      roll: current360ViewProps.roll,
+      fov: current360ViewProps.fov
+    });
+
+    self.user360DragingLastLocation = {
+      x: event.clientX,
+      y: event.clientY
+    };
+
+    self.last360UpdateTime = Date.now();
+  });
+
+  $(window).on('mouseup', (event) => {
+    self.user360Draging = false;
+  });
 };
 
 /**


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Feature: this PR adds basic support for 360 degree videos by using functions added with https://github.com/h5p/h5p-video/pull/176. Resolves https://github.com/h5p/h5p-interactive-video/issues/409.

**What is the current behaviour?**
360 degree videos can currently be added and played without issue. However, our users informed us, that recently, mouse control of the camera view in the YouTube player stopped working. In #409, it was discovered, that this is most likely due to a logic change within the embedded YouTube player. I also tested this with the Vimeo player - mouse control of the camera view is also non-functional there. 

**What is the new behaviour?**
On first play of the video, a `<div>` overlay is created over the video and mouse/touch listeners are added to it. The listeners use H5P Video module functions, added with https://github.com/h5p/h5p-video/pull/176, to move the camera view via each player's API functions. This enables view adjustment in YouTube and Vimeo players. For both of these, the `<div>` overlay is also constructed from multiple `<div>` elements to avoid and maintain the functionality of native UI elements in the players.

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

If anything else is required or requires changing, please let me know.
Additional discussion about this can be found here - https://github.com/h5p/h5p-interactive-video/issues/409