### PR TITLE
Fix task detection

### DIFF
--- a/src/scripts/interaction.js
+++ b/src/scripts/interaction.js
@@ -988,7 +988,7 @@ function Interaction(parameters, player, previousState) {
         }
 
         self.remove();
-        continueWithVideo(adaptivity.seekTo);  
+        continueWithVideo(adaptivity.seekTo);
         },
         true,
         {},

--- a/src/scripts/interaction.js
+++ b/src/scripts/interaction.js
@@ -1,3 +1,5 @@
+import { isInstanceTask } from './util.js';
+
 const $ = H5P.jQuery;
 
 /**
@@ -1494,9 +1496,7 @@ function Interaction(parameters, player, previousState) {
 
       if (!player.isTask && player.options.assets.endscreens !== undefined) {
         // IV is not a task by default, but it will be if one of the elements is a task or have a solution + there is a submit screen
-        if (instance.isTask || (instance.isTask === undefined && instance.showSolutions !== undefined)) {
-          player.isTask = true; // (checking for showSolutions will not work for compound content types, which is why we added isTask instead.)
-        }
+        player.isTask = isInstanceTask(instance);
       }
 
       // Set adaptivity if question is finished on attach

--- a/src/scripts/util.js
+++ b/src/scripts/util.js
@@ -1,0 +1,28 @@
+/**
+ * Determine whether H5P instance is task.
+ * @param {H5P.ContentType} instance Instance candidate.
+ * @returns {boolean} True, if instance is task.
+ */
+export const isInstanceTask = (instance = {}) => {
+  if (typeof instance !== 'object' || instance === null) {
+    return false;
+  }
+
+  if (typeof instance.isTask === 'boolean') {
+    return instance.isTask; // Content will declare if it's task on its own.
+  }
+
+  // Check for hasShowSolutions as indicator for being task.
+  const hasShowSolutions = (typeof instance.hasShowSolutions === 'function');
+  if (hasShowSolutions) {
+    return true;
+  }
+
+  // Check for maxScore > 0 as indicator for being task
+  const hasGetMaxScore = (typeof instance.getMaxScore === 'function');
+  if (hasGetMaxScore && instance.getMaxScore() > 0) {
+    return true;
+  }
+
+  return false;
+};


### PR DESCRIPTION
**What kind of change does this PR introduce?**
Bug fix

**What is the current behaviour?**
Interactive Video fails to reliably detect whether a subcontent is a "task" and will report that wrong to parent content, cmp. https://github.com/h5p/h5p-course-presentation/issues/418

**What is the new behaviour?**
Amended the logic to determine whether a subcontent is a "task" to also consider a maximum score > 0 as an indicator for being a task.

Fixes https://github.com/h5p/h5p-course-presentation/issues/418

## PR Checklist

Before submitting, please confirm:

- [x] I searched for existing issues/PRs first
- [x] I linked related issues/discussions
- [x] I tested my changes locally

Read the [contribution guidelines](https://github.com/h5p/.github/blob/master/CONTRIBUTING.md) to get your pr accepted more quickly.
